### PR TITLE
Up deployment target to 10.3. Required in order to move firefox to 10.3.

### DIFF
--- a/Telemetry.xcodeproj/project.pbxproj
+++ b/Telemetry.xcodeproj/project.pbxproj
@@ -560,7 +560,7 @@
 				);
 				INFOPLIST_FILE = Telemetry/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.Telemetry;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -585,7 +585,7 @@
 				);
 				INFOPLIST_FILE = Telemetry/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.Telemetry;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
I dont think this should affect Focus. 
This just says that Telemetry requires at least 10.3 and above. 