### PR TITLE
WIP: grab error-reporting code from this and close it

### DIFF
--- a/Telemetry/TelemetryError.swift
+++ b/Telemetry/TelemetryError.swift
@@ -16,4 +16,5 @@ public class TelemetryError {
     public static let InvalidUploadURL: Int = 103
     public static let CannotGenerateJSON: Int = 104
     public static let UnknownUploadError: Int = 105
+    public static let CannotGeneratePing: Int = 106
 }

--- a/TelemetryTests/TelemetryTests.swift
+++ b/TelemetryTests/TelemetryTests.swift
@@ -49,27 +49,11 @@ class TelemetryTests: XCTestCase {
 
         expectation = expectation(description: "Completed upload")
 
-//        Telemetry.default.scheduleUpload { (data, error) in
-//            let json = JSON(data ?? Data())
-//
-//            XCTAssert(error == nil, "Received didUpload(...) callback without an error")
-//            XCTAssert(json["foo"] == "bar", "Received didUpload(...) callback with expected JSON result")
-//
-//            callback.fulfill()
-//        }
-
         waitForExpectations(timeout: 60.0) { error in
             if error != nil {
                 print("Test timed out waiting for upload: %@", error!)
                 return
             }
-        }
-    }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
         }
     }
 }


### PR DESCRIPTION
Writing to the active core ping file can't conflict with the uploader anymore.
Files entering the upload state are renamed.
The uploader iterates all these renamed files and uploads each one.

