### PR TITLE
Backup fix #48: Ignore pings that arrive during upload

### DIFF
--- a/Telemetry/TelemetryScheduler.swift
+++ b/Telemetry/TelemetryScheduler.swift
@@ -29,17 +29,7 @@ public class TelemetryScheduler {
                 return
             }
 
-            // Get the next ping in the sequence.
-            var nextPing = pingSequence.next()
-
-            // If there are no remaining pings in the sequence, get a new sequence from
-            // storage in case any additional pings were queued while we were uploading.
-            if nextPing == nil {
-                pingSequence = storage.sequenceForPingType(pingType)
-                nextPing = pingSequence.next()
-            }
-
-            guard let ping = nextPing else {
+            guard let ping = pingSequence.next() else {
                 completionHandler()
                 return
             }


### PR DESCRIPTION
The existing code would update the file listing when
iteration complete, but the files are still on disk.

If we are in an extreme hurry to land something, this is a minimal solution to consider.