### PR TITLE
Test uploads and handle 5xx errors

### DIFF
--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -14,7 +14,7 @@ public typealias BeforeSerializePingHandler = ([String: Any?]) -> [String: Any?]
 public class Telemetry {
     public let configuration: TelemetryConfiguration
     
-    private let storage: TelemetryStorage
+    let storage: TelemetryStorage
     private let scheduler: TelemetryScheduler
 
     private var beforeSerializePingHandlers = [String : [BeforeSerializePingHandler]]()

--- a/Telemetry/TelemetryStorage.swift
+++ b/Telemetry/TelemetryStorage.swift
@@ -132,4 +132,14 @@ public class TelemetryStorage {
             return nil
         }
     }
+
+    func clear(pingType: String) {
+        guard let url = directoryForPingType(pingType) else { return }
+        do {
+            try FileManager.default.removeItem(at: url)
+        }
+        catch {
+            print("\(#function) \(error)")
+        }
+    }
 }

--- a/TelemetryTests/TelemetryTests.swift
+++ b/TelemetryTests/TelemetryTests.swift
@@ -28,8 +28,10 @@ class TelemetryTests: XCTestCase {
         telemetryConfig.dataDirectory = .documentDirectory
 
         Telemetry.default.storage.clear(pingType: CorePingBuilder.PingType)
+        Telemetry.default.storage.set(key: "\(CorePingBuilder.PingType)-lastUploadTimestamp", value: 0)
 
         Telemetry.default.add(pingBuilderType: CorePingBuilder.self)
+
     }
 
     override func tearDown() {


### PR DESCRIPTION
The commits are split into adding test cases and updating the scheduler for 5xx errors (bug #36). The latter was needed here for the tests to pass.
I can split these into different PRs instead.