### PR TITLE
[nobug, cleanup] Change access modifiers to internal wherever possible.

### DIFF
--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -12,9 +12,11 @@ import UIKit
 public typealias BeforeSerializePingHandler = ([String: Any?]) -> [String: Any?]
 
 public class Telemetry {
-    public let configuration: TelemetryConfiguration
-    
-    private let storage: TelemetryStorage
+    public let configuration = TelemetryConfiguration()
+
+    let app = AppEvents()
+    let storage: TelemetryStorage
+
     private let scheduler: TelemetryScheduler
 
     private var beforeSerializePingHandlers = [String : [BeforeSerializePingHandler]]()
@@ -28,10 +30,7 @@ public class Telemetry {
         return Telemetry(storageName: "MozTelemetry-Default")
     }()
 
-    let app = AppEvents()
     public init(storageName: String) {
-        self.configuration = TelemetryConfiguration()
-        
         self.storage = TelemetryStorage(name: storageName, configuration: configuration)
         self.scheduler = TelemetryScheduler(configuration: configuration, storage: storage)
     }
@@ -42,17 +41,17 @@ public class Telemetry {
         backgroundTasks[pingBuilderType.PingType] = UIBackgroundTaskInvalid
     }
 
-    public func hasPingType(_ pingType: String) -> Bool {
+    func hasPingType(_ pingType: String) -> Bool {
         return pingBuilders[pingType] != nil
     }
 
-    public func forEachPingType(_ iterator: (String) -> Void) {
+    func forEachPingType(_ iterator: (String) -> Void) {
         for (pingType, _) in pingBuilders {
             iterator(pingType)
         }
     }
 
-    public func queue(pingType: String) {
+    func queue(pingType: String) {
         if !self.configuration.isCollectionEnabled {
             return
         }
@@ -72,7 +71,7 @@ public class Telemetry {
         }
     }
 
-    public func scheduleUpload(pingType: String) {
+    func scheduleUpload(pingType: String) {
         guard configuration.isUploadEnabled,
             let backgroundTask = backgroundTasks[pingType],
             backgroundTask == UIBackgroundTaskInvalid else {
@@ -100,7 +99,7 @@ public class Telemetry {
         }
     }
 
-    public func recordSessionStart() {
+    func recordSessionStart() {
         if !configuration.isCollectionEnabled {
             return
         }
@@ -113,7 +112,7 @@ public class Telemetry {
         pingBuilder.startSession()
     }
 
-    public func recordSessionEnd() {
+    func recordSessionEnd() {
         if !configuration.isCollectionEnabled {
             return
         }

--- a/Telemetry/TelemetryClient.swift
+++ b/Telemetry/TelemetryClient.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-public class TelemetryClient: NSObject {
+class TelemetryClient: NSObject {
     private let configuration: TelemetryConfiguration
 
-    public init(configuration: TelemetryConfiguration) {
+    init(configuration: TelemetryConfiguration) {
         self.configuration = configuration
     }
 
     // The closure is called with an HTTP status code (zero if unavailable) and an error
-    public func upload(ping: TelemetryPing, completionHandler: @escaping (Int, Error?) -> Void) -> Void {
+    func upload(ping: TelemetryPing, completionHandler: @escaping (Int, Error?) -> Void) -> Void {
         guard let url = URL(string: "\(configuration.serverEndpoint)\(ping.uploadPath)") else {
             let error = NSError(domain: TelemetryError.ErrorDomain, code: TelemetryError.InvalidUploadURL, userInfo: [NSLocalizedDescriptionKey: "Invalid upload URL: \(configuration.serverEndpoint)\(ping.uploadPath)"])
             

--- a/Telemetry/TelemetryPing.swift
+++ b/Telemetry/TelemetryPing.swift
@@ -23,7 +23,7 @@ public class TelemetryPing {
         self.timestamp = timestamp
     }
     
-    public static func from(dictionary: [String : Any]) -> TelemetryPing? {
+    static func from(dictionary: [String : Any]) -> TelemetryPing? {
         if let pingType = dictionary["pingType"] as? String,
            let documentId = dictionary["documentId"] as? String,
            let uploadPath = dictionary["uploadPath"] as? String,
@@ -35,11 +35,11 @@ public class TelemetryPing {
         return nil
     }
     
-    public func toDictionary() -> [String : Any] {
+    func toDictionary() -> [String : Any] {
         return ["timestamp": timestamp, "pingType": pingType, "documentId": documentId, "uploadPath": uploadPath, "measurements": measurements]
     }
     
-    public func measurementsJSON() -> Data? {
+    func measurementsJSON() -> Data? {
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: measurements, options: [])
             return jsonData

--- a/Telemetry/TelemetryPingBuilder.swift
+++ b/Telemetry/TelemetryPingBuilder.swift
@@ -22,7 +22,7 @@ public class TelemetryPingBuilder {
     fileprivate let configuration: TelemetryConfiguration
     fileprivate let storage: TelemetryStorage
 
-    public var canBuild: Bool {
+    var canBuild: Bool {
         get { return true }
     }
     
@@ -37,7 +37,7 @@ public class TelemetryPingBuilder {
         measurements.append(measurement)
     }
     
-    public func build(usingHandlers handlers: [BeforeSerializePingHandler]?) -> TelemetryPing {
+    func build(usingHandlers handlers: [BeforeSerializePingHandler]?) -> TelemetryPing {
         let pingType = type(of: self).PingType
         let documentId = UUID.init().uuidString
         let uploadPath = getUploadPath(withDocumentId: documentId)
@@ -50,7 +50,7 @@ public class TelemetryPingBuilder {
         return TelemetryPing(pingType: pingType, documentId: documentId, uploadPath: uploadPath, measurements: data, timestamp: Date().timeIntervalSince1970)
     }
     
-    public func getUploadPath(withDocumentId documentId: String) -> String {
+    func getUploadPath(withDocumentId documentId: String) -> String {
         let pingType = type(of: self).PingType
         let appName = configuration.appName
         let appVersion = configuration.appVersion
@@ -109,11 +109,11 @@ public class CorePingBuilder: TelemetryPingBuilder {
         self.add(measurement: self.searchesMeasurement)
     }
 
-    override public func getUploadPath(withDocumentId documentId: String) -> String {
+    override func getUploadPath(withDocumentId documentId: String) -> String {
         return super.getUploadPath(withDocumentId: documentId) + "?v=4"
     }
 
-    public func startSession() {
+    func startSession() {
         do {
             try sessionDurationMeasurement.start()
         } catch {
@@ -124,7 +124,7 @@ public class CorePingBuilder: TelemetryPingBuilder {
         sessionCountMeasurement.increment()
     }
     
-    public func endSession() {
+    func endSession() {
         do {
             try sessionDurationMeasurement.end()
         } catch {
@@ -148,13 +148,13 @@ public class FocusEventPingBuilder: TelemetryPingBuilder {
     
     private let eventsMeasurement: EventsMeasurement
     
-    public var numberOfEvents: Int {
+    var numberOfEvents: Int {
         get {
             return eventsMeasurement.numberOfEvents
         }
     }
     
-    override public var canBuild: Bool {
+    override var canBuild: Bool {
         get {
             return eventsMeasurement.numberOfEvents >= configuration.minimumEventsForUpload
         }
@@ -178,7 +178,7 @@ public class FocusEventPingBuilder: TelemetryPingBuilder {
         self.add(measurement: self.eventsMeasurement)
     }
     
-    override public func getUploadPath(withDocumentId documentId: String) -> String {
+    override func getUploadPath(withDocumentId documentId: String) -> String {
         return super.getUploadPath(withDocumentId: documentId) + "?v=4"
     }
     

--- a/Telemetry/TelemetryScheduler.swift
+++ b/Telemetry/TelemetryScheduler.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class TelemetryScheduler {
+class TelemetryScheduler {
     private let configuration: TelemetryConfiguration
     private let storage: TelemetryStorage
     
@@ -20,7 +20,7 @@ public class TelemetryScheduler {
         self.client = TelemetryClient(configuration: configuration)
     }
     
-    public func scheduleUpload(pingType: String, completionHandler: @escaping () -> Void) {
+    func scheduleUpload(pingType: String, completionHandler: @escaping () -> Void) {
         var pingSequence = storage.sequenceForPingType(pingType)
 
         func uploadNextPing() {

--- a/Telemetry/TelemetryStorage.swift
+++ b/Telemetry/TelemetryStorage.swift
@@ -72,20 +72,20 @@ public class TelemetryStorage {
     // Prepend to all key usage to avoid UserDefaults name collisions
     private let keyPrefix = "telemetry-key-prefix-"
 
-    public init(name: String, configuration: TelemetryConfiguration) {
+    init(name: String, configuration: TelemetryConfiguration) {
         self.name = name
         self.configuration = configuration
     }
 
-    public func get(valueFor key: String) -> Any? {
+    func get(valueFor key: String) -> Any? {
         return UserDefaults.standard.object(forKey: keyPrefix + key)
     }
 
-    public func set(key: String, value: Any) {
+    func set(key: String, value: Any) {
         UserDefaults.standard.set(value, forKey: keyPrefix + key)
     }
 
-    public func enqueue(ping: TelemetryPing) {
+    func enqueue(ping: TelemetryPing) {
         guard let directory = directoryForPingType(ping.pingType) else {
             print("TelemetryStorage.enqueue(): Could not get directory for pingType '\(ping.pingType)'")
             return

--- a/Telemetry/TelemetryUtils.swift
+++ b/Telemetry/TelemetryUtils.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-public class TelemetryUtils {
-    public static func asString(_ object: Any?) -> String {
+class TelemetryUtils {
+    static func asString(_ object: Any?) -> String {
         if let string = object as? String {
             return string
         } else if let bool = object as? Bool {
@@ -19,7 +19,7 @@ public class TelemetryUtils {
         }
     }
     
-    public static func truncate(string: String?, maxLength: Int) -> String? {
+    static func truncate(string: String?, maxLength: Int) -> String? {
         guard let string = string else {
             return nil
         }


### PR DESCRIPTION
This will allow easier code changes in future (non-public functions can have signatures changed freely).
Also makes for easier identification of entry points to the lib.