### PR TITLE
Fix #56: Remove stale files

### DIFF
--- a/Telemetry/TelemetryConfiguration.swift
+++ b/Telemetry/TelemetryConfiguration.swift
@@ -24,7 +24,7 @@ public class TelemetryConfiguration {
     public var maximumNumberOfEventsPerPing = TelemetryDefaults.MaxNumberOfEventsPerPing
     public var maximumNumberOfPingsPerType = TelemetryDefaults.MaxNumberOfPingsPerType
     public var maximumNumberOfPingUploadsPerDay = TelemetryDefaults.MaxNumberOfPingUploadsPerDay
-    public var maxNumberOfUploadAttemptsPerPing = TelemetryDefaults.MaxNumberOfUploadAttemptsPerPing
+    public var maximumAgeOfPingInDays = TelemetryDefaults.MaxAgeOfPingInDays
 
     public var isCollectionEnabled = true
     public var isUploadEnabled = true

--- a/Telemetry/TelemetryDefaults.swift
+++ b/Telemetry/TelemetryDefaults.swift
@@ -23,5 +23,5 @@ public class TelemetryDefaults {
     public static let MaxNumberOfEventsPerPing = 500
     public static let MaxNumberOfPingsPerType = 40
     public static let MaxNumberOfPingUploadsPerDay = 100
-    public static let MaxAgeOfPingInDays = 5
+    public static let MaxAgeOfPingInDays = 10
 }

--- a/Telemetry/TelemetryDefaults.swift
+++ b/Telemetry/TelemetryDefaults.swift
@@ -23,5 +23,5 @@ public class TelemetryDefaults {
     public static let MaxNumberOfEventsPerPing = 500
     public static let MaxNumberOfPingsPerType = 40
     public static let MaxNumberOfPingUploadsPerDay = 100
-    public static let MaxNumberOfUploadAttemptsPerPing = 10
+    public static let MaxAgeOfPingInDays = 5
 }

--- a/Telemetry/TelemetryUtils.swift
+++ b/Telemetry/TelemetryUtils.swift
@@ -26,4 +26,8 @@ class TelemetryUtils {
         
         return String(string.characters.prefix(maxLength))
     }
+
+    static func daysBetween(start: Date, end: Date) -> Int {
+        return Calendar.current.dateComponents([.day], from: start, to: end).day ?? 0
+    }
 }

--- a/TelemetryTests/TelemetryTests.swift
+++ b/TelemetryTests/TelemetryTests.swift
@@ -139,5 +139,13 @@ class TelemetryTests: XCTestCase {
         XCTWaiter().wait(for: [expectation(description: "process async events")], timeout: 1)
         XCTAssert(countFilesOnDisk() == 0, "Confirm no more upload files")
     }
+
+    func testFileTimestamp() {
+        let lastWeek = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
+        let fileDate = TelemetryStorage.extractTimestampFromName(pingFile: URL(string: "a/b/c/foo-t-\(lastWeek.timeIntervalSince1970).json")!)!
+        XCTAssert(fileDate.timeIntervalSince1970 > 0)
+        XCTAssert(fabs(fileDate.timeIntervalSince1970 - lastWeek.timeIntervalSince1970) < 0.1 /* epsilon */)
+        XCTAssert(TelemetryUtils.daysBetween(start: fileDate, end: Date()) == 7)
+    }
 }
 


### PR DESCRIPTION
Arbitrarily set 5 days as the default.
Added test cases.
Consider adding notification logging for this so we can track in Sentry.