### PR TITLE
Fix #54: make print() a no-op in non-debug builds

### DIFF
--- a/Telemetry/TelemetryUtils.swift
+++ b/Telemetry/TelemetryUtils.swift
@@ -4,6 +4,11 @@
 
 import Foundation
 
+#if !DEBUG
+    // Turn print into a no-op in non-debug builds.
+    func print(_ items: Any..., separator: String = " ", terminator: String = "\n") {}
+#endif
+
 class TelemetryUtils {
     static func asString(_ object: Any?) -> String {
         if let string = object as? String {


### PR DESCRIPTION
I love this macro because it is fail-safe, unless DEBUG is specified in the build, print is a no-op.