### PR TITLE
Fix #61: Save event array by appending to file

### DIFF
--- a/Telemetry/TelemetryEvent.swift
+++ b/Telemetry/TelemetryEvent.swift
@@ -13,8 +13,6 @@ public class TelemetryEvent {
     public static let MaxNumberOfExtras = 10
     public static let MaxLengthExtraKey = 15
     public static let MaxLengthExtraValue = 80
-    
-    public static let ExtrasDefaultValue = ""
 
     private static let AppLaunchTimestamp: Date = Date()
 
@@ -82,8 +80,9 @@ public class TelemetryEvent {
         }
 
         if !extras.isEmpty {
-            let value = self.value ?? TelemetryEvent.ExtrasDefaultValue
-            array.append(value)
+            if value == nil {
+                array.append(nil)
+            }
             array.append(extras)
         }
 

--- a/TelemetryTests/TelemetryTests.swift
+++ b/TelemetryTests/TelemetryTests.swift
@@ -114,9 +114,16 @@ class TelemetryTests: XCTestCase {
         Telemetry.default.recordEvent(category: "category", method: "method", object: "object", value: "value", extras: ["extraKey": nil])
         Telemetry.default.recordEvent(category: "category", method: "method", object: "object", value: nil, extras: ["extraKey": nil])
 
+        wait()
+        var count = Telemetry.default.storage.countArrayFileEvents(forPingType: FocusEventPingBuilder.PingType)
+        XCTAssert(count == 4)
+
         // Write events to a file
         Telemetry.default.queue(pingType: FocusEventPingBuilder.PingType)
         waitForFilesOnDisk(count: 1, pingType: FocusEventPingBuilder.PingType)
+
+        count = Telemetry.default.storage.countArrayFileEvents(forPingType: FocusEventPingBuilder.PingType)
+        XCTAssert(count == 0)
 
         setupHttpResponseStub(expectedFilesUploaded: 1, statusCode: 200, eventCount: 4)
         upload(pingType: FocusEventPingBuilder.PingType)


### PR DESCRIPTION
The events are saved to a file as a JSON snippet, appending each array, for instance this is what 2 events would look like (the second having an extra dict):
`[a,b,c,d], [e,f,g,h,{"foo":"doo"}]`
The event flush() reads the whole file and deletes it.

EventsMeasurement has `eventsAddedToFile` which tracks events added this session, and must be greater than the config minimumEventsForUpload in order to upload.
On startup, it doesn't count the events in the file, but it only takes a few events during the session to exceed the minimumEventsForUpload.
I could change this if needed to count the events already stored in the file.