### PR TITLE
 Fix #63: Add TelemetryEventPingBuilder type as parent of FocusEventPingBuilder

### DIFF
--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -141,7 +141,7 @@ public class Telemetry {
             pingBuilder.add(event: event)
 
             if pingBuilder.numberOfEvents >= self.configuration.maximumNumberOfEventsPerPing {
-                self.queue(pingType: FocusEventPingBuilder.PingType)
+                self.queue(pingType: type)
             }
         }
     }

--- a/Telemetry/TelemetryConfiguration.swift
+++ b/Telemetry/TelemetryConfiguration.swift
@@ -27,7 +27,11 @@ public class TelemetryConfiguration {
 
     public var userDefaultsSuiteName: String?
     private(set) public var measuredUserDefaults: [[String : Any?]]
-    
+
+    // This is used for adding multiple TelemetryEventPingBuilder classes.
+    // Use this to specify the default one for Telemetry.recordEvent(), or ensure to specify the pingType in all recordEvent() calls.
+    public var defaultEventPingBuilderType: String?
+
     public init() {
         let info = Bundle.main.infoDictionary
 


### PR DESCRIPTION
This allows easily subclassing TelemetryEventPingBuilder to create the Firefox event ping builder.