### PR TITLE
 Don't report NSError for network connection problems

### DIFF
--- a/Telemetry/Telemetry.swift
+++ b/Telemetry/Telemetry.swift
@@ -20,7 +20,7 @@ public class Telemetry {
     private var backgroundTasks = [String : UIBackgroundTaskIdentifier]()
 
     // Use this to monitor upload errors from outside of this library
-    public static let notificationUploadError = Notification.Name("NotificationTelemetryUploadError")
+    public static let notificationReportError = Notification.Name("NotificationTelemetryErrorReport")
 
     public static let `default`: Telemetry = {
         return Telemetry(storageName: "MozTelemetry-Default")

--- a/Telemetry/TelemetryClient.swift
+++ b/Telemetry/TelemetryClient.swift
@@ -15,19 +15,15 @@ class TelemetryClient: NSObject {
     func upload(ping: TelemetryPing, completionHandler: @escaping (Int, Error?) -> Void) -> Void {
         guard let url = URL(string: "\(configuration.serverEndpoint)\(ping.uploadPath)") else {
             let error = NSError(domain: TelemetryError.ErrorDomain, code: TelemetryError.InvalidUploadURL, userInfo: [NSLocalizedDescriptionKey: "Invalid upload URL: \(configuration.serverEndpoint)\(ping.uploadPath)"])
-            
-            print(error.localizedDescription)
             completionHandler(0, error)
-            NotificationCenter.default.post(name: Telemetry.notificationUploadError, object: nil, userInfo: ["error": error])
+            report(error: error)
             return
         }
         
         guard let data = ping.measurementsJSON() else {
             let error = NSError(domain: TelemetryError.ErrorDomain, code: TelemetryError.CannotGenerateJSON, userInfo: [NSLocalizedDescriptionKey: "Error generating JSON data for TelemetryPing"])
-
-            print(error.localizedDescription)
             completionHandler(0, error)
-            NotificationCenter.default.post(name: Telemetry.notificationUploadError, object: nil, userInfo: ["error": error])
+            report(error: error)
             return
         }
 
@@ -51,7 +47,7 @@ class TelemetryClient: NSObject {
 
                 let err = error ?? NSError(domain: TelemetryError.ErrorDomain, code: TelemetryError.UnknownUploadError, userInfo: nil)
                 completionHandler(statusCode, err)
-                NotificationCenter.default.post(name: Telemetry.notificationUploadError, object: nil, userInfo: ["error": err])
+                report(error: err)
             }
         }
         task.resume()

--- a/Telemetry/TelemetryUtils.swift
+++ b/Telemetry/TelemetryUtils.swift
@@ -9,6 +9,18 @@ import Foundation
     func print(_ items: Any..., separator: String = " ", terminator: String = "\n") {}
 #endif
 
+// Will print the error, and if it is not a simple network connection problem, report it to the client app.
+func report(error: Error) {
+    print(error)
+
+    let code = (error as NSError).code
+    let errorsNotReported = [NSURLErrorNotConnectedToInternet, NSURLErrorCancelled, NSURLErrorTimedOut, NSURLErrorInternationalRoamingOff, NSURLErrorDataNotAllowed, NSURLErrorCannotFindHost, NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost]
+    if errorsNotReported.contains(code) {
+        return
+    }
+    NotificationCenter.default.post(name: Telemetry.notificationReportError, object: nil, userInfo: ["error": error])
+}
+
 extension UInt64 {
     static func safeConvert<T: FloatingPoint>(_ val: T) -> UInt64 {
         let d = val as? Double ?? 0.0

--- a/TestApp/AppDelegate.swift
+++ b/TestApp/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         Telemetry.default.add(pingBuilderType: CorePingBuilder.self)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(uploadError(notification:)), name: Telemetry.notificationUploadError, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(uploadError(notification:)), name: Telemetry.notificationReportError, object: nil)
 
         return true
     }


### PR DESCRIPTION
Part of https://bugzilla.mozilla.org/show_bug.cgi?id=1411389

Due to change of notificationUploadError to notificationReportError, also need a patch in Firefox iOS.

We can start using this report(error:) function in places where unhandled errors are printed.