### PR TITLE
Issue #73: explicitly ignore 3xx HTTP errors

### DIFF
--- a/Telemetry/TelemetryScheduler.swift
+++ b/Telemetry/TelemetryScheduler.swift
@@ -30,8 +30,8 @@ class TelemetryScheduler {
                 let errorCode = (error as NSError?)?.code ?? 0
                 let errorRequiresDelete = [TelemetryError.InvalidUploadURL, TelemetryError.CannotGenerateJSON].contains(errorCode)
 
-                // Arguably, this could be (200..<500).contains(httpStatusCode) and 5xx errors could be handled more selectively to decide whether to delete the ping.
-                if (200..<500).contains(httpStatusCode) || errorRequiresDelete {
+                // Delete the ping on any 2xx or 4xx status code.
+                if [2,4].contains(Int(httpStatusCode / 100)) || errorRequiresDelete {
                     // Network call completed, successful or with error, delete the ping, and upload the next ping.
                     pingSequence.remove()
                     self.incrementDailyUploadCount(forPingType: pingType)

--- a/TelemetryTests/TelemetryTests.swift
+++ b/TelemetryTests/TelemetryTests.swift
@@ -87,6 +87,8 @@ class TelemetryTests: XCTestCase {
     }
 
     private func storeOnDiskAndUpload(corePingFilesToWrite: Int) {
+        let startSeq = Telemetry.default.storage.get(valueFor: "\(CorePingBuilder.PingType)-seq") as! Int
+
         for _ in 0..<corePingFilesToWrite {
             Telemetry.default.recordSessionStart()
             Telemetry.default.recordSessionEnd()
@@ -95,6 +97,9 @@ class TelemetryTests: XCTestCase {
 
         waitForFilesOnDisk(count: corePingFilesToWrite)
         upload(pingType: CorePingBuilder.PingType)
+
+        let endSeq = Telemetry.default.storage.get(valueFor: "\(CorePingBuilder.PingType)-seq") as! Int
+        XCTAssert(endSeq - startSeq == corePingFilesToWrite)
     }
 
     private func waitForFilesOnDisk(count: Int, pingType: String = CorePingBuilder.PingType) {
@@ -153,6 +158,7 @@ class TelemetryTests: XCTestCase {
         storeOnDiskAndUpload(corePingFilesToWrite: filesOnDisk)
         waitForFilesOnDisk(count: filesOnDisk)
     }
+
 
     func test4xxCode() {
         setupHttpResponseStub(expectedFilesUploaded: 3, statusCode: 400)


### PR DESCRIPTION
Issue #73 is not a bug (the error code 310 in that bug is not an HTTP code, and is correctly handled). The Sentry logging can make it *appear* that we are getting a 310 HTTP code.
HTTP code 3xx errors never bubble up to the TelemetryScheduler
as they are internally handled by URLSession (and may get reported as other
forms of URL connection errors). The existing code is correct.

For readability, perhaps it is better to be explicit here that we would not delete the ping if 3xx error happens. 