### PR TITLE
Add Cocoapods support

### DIFF
--- a/MozillaTelemetry.podspec
+++ b/MozillaTelemetry.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = "MozillaTelemetry"
+  s.version      = "1.0.6"
+  s.summary      = "A generic library for sending telemetry pings from iOS applications to Mozilla's telemetry service."
+  s.homepage     = "https://github.com/mozilla-mobile/telemetry-ios"
+  s.license      = { :type => "Mozilla Public License", :file => "LICENSE" }
+  s.author    = ""
+  s.source       = { :git => "https://github.com/mozilla-mobile/telemetry-ios.git", :tag => "v#{s.version}" }
+  s.source_files  = "Telemetry/**/*.{h,m,swift}"
+  s.platform = :ios, '9.0' 
+end


### PR DESCRIPTION
Fixes #29.

This adds the minimum support needed for users to pull down the latest tagged version of this library with Cocoapods.

When a new version is released, all that needs to be changed is `s.version` to reflect the new version number in `MozillaTelemetry.podspec`.

You can read more about the podspec syntax [here](https://guides.cocoapods.org/syntax/podspec.html), and submitting the library to the public Specs repo [here](https://guides.cocoapods.org/making/making-a-cocoapod.html#release), although that may not be needed if there is little other demand for Pods support.